### PR TITLE
bump SPI version 0.1.0 → 0.2.0 to force re-fetch of fixed picture jar

### DIFF
--- a/docs/deployment-nixos.md
+++ b/docs/deployment-nixos.md
@@ -17,7 +17,7 @@ Every release attaches the following artifacts to the GitHub release:
 | `helpwave-privacy-<VER>.jar`               | `privacy/`                             | `FormAction` SPI: privacy checkbox + acceptance attrs.    |
 | `helpwave-picture-<VER>.jar`               | `picture/`                             | `RealmResourceProvider` SPI: avatar upload to S3 / R2.    |
 
-`<VER>` is the SPI Maven version (`keycloak-extensions/pom.xml`, currently `0.1.0`),
+`<VER>` is the SPI Maven version (`keycloak-extensions/pom.xml`, currently `0.2.0`),
 which is independent from the theme/npm version in `package.json`. All four jars go into
 Keycloak's `providers/` directory — `services.keycloak.plugins` does that for you.
 
@@ -28,8 +28,8 @@ Keycloak's `providers/` directory — `services.keycloak.plugins` does that for 
 let
   domain = "id.helpwave.de";
 
-  themeVersion = "0.4.0";   # ⇄ package.json version → release tag v0.4.0
-  spiVersion   = "0.1.0";   # ⇄ keycloak-extensions/pom.xml
+  themeVersion = "0.5.0";   # ⇄ package.json version → release tag v0.5.0
+  spiVersion   = "0.2.0";   # ⇄ keycloak-extensions/pom.xml
 
   release = file: sha:
     pkgs.fetchurl {
@@ -119,7 +119,7 @@ in
 >
 > ```sh
 > nix-prefetch-url --type sha256 \
->   "https://github.com/helpwave/id.helpwave.de/releases/download/v0.4.0/helpwave-picture-0.1.0.jar"
+>   "https://github.com/helpwave/id.helpwave.de/releases/download/v0.5.0/helpwave-picture-0.2.0.jar"
 > ```
 >
 > Or just run `nixos-rebuild switch` once with all four `sha256-AAA…` placeholders, copy

--- a/keycloak-extensions/captcha/pom.xml
+++ b/keycloak-extensions/captcha/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>de.helpwave.keycloak</groupId>
         <artifactId>helpwave-keycloak-extensions</artifactId>
-        <version>0.1.0</version>
+        <version>0.2.0</version>
     </parent>
 
     <artifactId>helpwave-captcha</artifactId>

--- a/keycloak-extensions/picture/pom.xml
+++ b/keycloak-extensions/picture/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>de.helpwave.keycloak</groupId>
         <artifactId>helpwave-keycloak-extensions</artifactId>
-        <version>0.1.0</version>
+        <version>0.2.0</version>
     </parent>
 
     <artifactId>helpwave-picture</artifactId>

--- a/keycloak-extensions/pom.xml
+++ b/keycloak-extensions/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>de.helpwave.keycloak</groupId>
     <artifactId>helpwave-keycloak-extensions</artifactId>
-    <version>0.1.0</version>
+    <version>0.2.0</version>
     <packaging>pom</packaging>
     <name>helpwave Keycloak Extensions</name>
     <description>Keycloak SPI extensions used by id.helpwave.de</description>

--- a/keycloak-extensions/privacy/pom.xml
+++ b/keycloak-extensions/privacy/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>de.helpwave.keycloak</groupId>
         <artifactId>helpwave-keycloak-extensions</artifactId>
-        <version>0.1.0</version>
+        <version>0.2.0</version>
     </parent>
 
     <artifactId>helpwave-privacy</artifactId>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "id.helpwave.de",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "repository": {
     "type": "git",
     "url": "git://github.com/helpwave/id.helpwave.de.git"


### PR DESCRIPTION
The previous release shipped helpwave-picture-0.1.0.jar that still had the buggy 3-arg constructor. The follow-up commit fixed the constructor but kept the same SPI version, so the GitHub release re-attached a jar with the same filename — NixOS deployments that already cached the sha256 of the old bytes silently kept pulling the broken artifact and Keycloak boot kept failing with the Arc UnsatisfiedResolutionException on PictureConfig / S3Storage injection.

Bumping the SPI version makes the filename change to helpwave-picture-0.2.0.jar (likewise captcha + privacy), so any nix-prefetch-url / fetchurl line has to be updated, which forces a real re-fetch of the fixed bytes. Theme version bumped 0.4.0 → 0.5.0 too so the release contains everything in one consistent tag.

docs/deployment-nixos.md now references themeVersion = "0.5.0" and spiVersion = "0.2.0" in the example Nix expression and the nix-prefetch-url snippet.