### PR TITLE
Upgrade hightide to 0.14.1 and fix team realm border

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,20 +10,20 @@
       "hasInstallScript": true,
       "license": "MPL-2",
       "dependencies": {
-        "@helpwave/hightide": "^0.8.1",
+        "@helpwave/hightide": "^0.14.1",
         "@keycloakify/email-native": "~260007.0.0",
         "keycloakify": "^11.14.2",
         "lucide-react": "^0.563.0",
-        "react": "^18.2.0",
-        "react-dom": "^18.2.0"
+        "react": "^19.2.7",
+        "react-dom": "^19.2.7"
       },
       "devDependencies": {
         "@eslint/js": "^9.15.0",
         "@helpwave/eslint-config": "^0.0.11",
         "@storybook/react-vite": "^10.2.8",
         "@tailwindcss/vite": "^4.1.18",
-        "@types/react": "^18.2.43",
-        "@types/react-dom": "^18.2.17",
+        "@types/react": "^19.2.17",
+        "@types/react-dom": "^19.2.3",
         "@typescript-eslint/eslint-plugin": "^8.15.0",
         "@typescript-eslint/parser": "^8.15.0",
         "@vitejs/plugin-react": "^4.2.1",
@@ -1015,19 +1015,25 @@
       }
     },
     "node_modules/@helpwave/hightide": {
-      "version": "0.8.1",
-      "resolved": "https://registry.npmjs.org/@helpwave/hightide/-/hightide-0.8.1.tgz",
-      "integrity": "sha512-hggMPUzGo6duekEHSd4vWsj2okcyGGszZhGzBNeS7KTe6nHcgs8YpW8J5IUwualZoO2C625gMv7zBogAV/qQxA==",
+      "version": "0.14.1",
+      "resolved": "https://registry.npmjs.org/@helpwave/hightide/-/hightide-0.14.1.tgz",
+      "integrity": "sha512-KWu6q4SZF4fCTzlRv1NmuQnMB2XBXtgvg64t4MG5vPZ6fLNw7ziafFXlY7lhUHHxzOvfnvd/+daos7jkJP1i8A==",
       "license": "MPL-2.0",
       "dependencies": {
         "@helpwave/internationalization": "0.4.0",
         "@tailwindcss/cli": "4.1.18",
         "@tanstack/react-table": "8.21.3",
+        "@tanstack/react-virtual": "3.14.3",
         "clsx": "2.1.1",
         "lucide-react": "0.561.0",
-        "react": "19.2.3",
-        "react-dom": "19.2.3",
         "tailwindcss": "4.1.18"
+      },
+      "bin": {
+        "barrel": "dist/scripts/barrel.js"
+      },
+      "peerDependencies": {
+        "react": "^19.0.0",
+        "react-dom": "^19.0.0"
       }
     },
     "node_modules/@helpwave/hightide/node_modules/lucide-react": {
@@ -1038,33 +1044,6 @@
       "peerDependencies": {
         "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
-    },
-    "node_modules/@helpwave/hightide/node_modules/react": {
-      "version": "19.2.3",
-      "resolved": "https://registry.npmjs.org/react/-/react-19.2.3.tgz",
-      "integrity": "sha512-Ku/hhYbVjOQnXDZFv2+RibmLFGwFdeeKHFcOTlrt7xplBnya5OGn/hIRDsqDiSUcfORsDC7MPxwork8jBwsIWA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/@helpwave/hightide/node_modules/react-dom": {
-      "version": "19.2.3",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.3.tgz",
-      "integrity": "sha512-yELu4WmLPw5Mr/lmeEpox5rw3RETacE++JgHqQzd2dg+YbJuat3jH4ingc+WPZhxaoFzdv9y33G+F7Nl5O0GBg==",
-      "license": "MIT",
-      "dependencies": {
-        "scheduler": "^0.27.0"
-      },
-      "peerDependencies": {
-        "react": "^19.2.3"
-      }
-    },
-    "node_modules/@helpwave/hightide/node_modules/scheduler": {
-      "version": "0.27.0",
-      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
-      "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
-      "license": "MIT"
     },
     "node_modules/@helpwave/internationalization": {
       "version": "0.4.0",
@@ -2080,14 +2059,13 @@
       "license": "MIT"
     },
     "node_modules/@storybook/icons": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@storybook/icons/-/icons-2.0.1.tgz",
-      "integrity": "sha512-/smVjw88yK3CKsiuR71vNgWQ9+NuY2L+e8X7IMrFjexjm6ZR8ULrV2DRkTA61aV6ryefslzHEGDInGpnNeIocg==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@storybook/icons/-/icons-2.1.0.tgz",
+      "integrity": "sha512-Fxh9vYpX9bQqFeHRiY8h2ApeRGDzRSMLwJwNZ/AIRqnyOKHxRKL+yFe+ctEkVJmuptRE9u1Hrn8ZZNHyfDKKNg==",
       "dev": true,
       "license": "MIT",
       "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
-        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/@storybook/react": {
@@ -2503,6 +2481,23 @@
         "react-dom": ">=16.8"
       }
     },
+    "node_modules/@tanstack/react-virtual": {
+      "version": "3.14.3",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-virtual/-/react-virtual-3.14.3.tgz",
+      "integrity": "sha512-k/cnHPVaOfn46hSbiY6n4Dzf4QjCGWSF40zR5QIIYUqPAjpA6TN7InfYmcMiDVQGP2iUn9xsRbAl8u1v3UmeVQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/virtual-core": "3.17.1"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
     "node_modules/@tanstack/table-core": {
       "version": "8.21.3",
       "resolved": "https://registry.npmjs.org/@tanstack/table-core/-/table-core-8.21.3.tgz",
@@ -2511,6 +2506,16 @@
       "engines": {
         "node": ">=12"
       },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
+    "node_modules/@tanstack/virtual-core": {
+      "version": "3.17.1",
+      "resolved": "https://registry.npmjs.org/@tanstack/virtual-core/-/virtual-core-3.17.1.tgz",
+      "integrity": "sha512-VZyW2Uiml5tmBZwPGrSD3Sz73OxzljQMCmzYHsUTPEuTsERf5xwa+uWb01xEzkz3ZSYTjj8NEb/mKHvgKxyZdA==",
+      "license": "MIT",
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/tannerlinsley"
@@ -2670,32 +2675,24 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/@types/prop-types": {
-      "version": "15.7.12",
-      "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.12.tgz",
-      "integrity": "sha512-5zvhXYtRNRluoE/jAp4GVsSduVUzNWKkOZrCDBWYtE7biZywwdC2AcEzg+cSMLFRfVgeAFqpfNabiPjxFddV1Q==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/@types/react": {
-      "version": "18.3.3",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.3.tgz",
-      "integrity": "sha512-hti/R0pS0q1/xx+TsI73XIqk26eBsISZ2R0wUijXIngRK9R/e7Xw/cXVxQK7R5JjW+SV4zGcn5hXjudkN/pLIw==",
+      "version": "19.2.17",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.17.tgz",
+      "integrity": "sha512-MXfmqaVPEVgkBT/aY0aGCkRWWtByiYQXo3xdQ8r5RzuFrPiRn8Gar2tQdXSUQ2GKV3bkXckek89V8wQBY2Q/Aw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@types/prop-types": "*",
-        "csstype": "^3.0.2"
+        "csstype": "^3.2.2"
       }
     },
     "node_modules/@types/react-dom": {
-      "version": "18.3.0",
-      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.3.0.tgz",
-      "integrity": "sha512-EhwApuTmMBmXuFOikhQLIBUn6uFg81SwLMOAUgodJF14SOBOCMdU04gDoYi0WOJJHD144TL32z4yDqCW3dnkQg==",
+      "version": "19.2.3",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.3.tgz",
+      "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
       "dev": true,
       "license": "MIT",
-      "dependencies": {
-        "@types/react": "*"
+      "peerDependencies": {
+        "@types/react": "^19.2.0"
       }
     },
     "node_modules/@types/resolve": {
@@ -3537,9 +3534,9 @@
       "license": "MIT"
     },
     "node_modules/csstype": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
-      "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
+      "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
       "dev": true,
       "license": "MIT"
     },
@@ -5347,6 +5344,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/js-yaml": {
@@ -5737,6 +5735,7 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
       "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "js-tokens": "^3.0.0 || ^4.0.0"
@@ -6323,13 +6322,10 @@
       "license": "MIT"
     },
     "node_modules/react": {
-      "version": "18.3.1",
-      "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
-      "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
+      "version": "19.2.7",
+      "resolved": "https://registry.npmjs.org/react/-/react-19.2.7.tgz",
+      "integrity": "sha512-HNe9WslTbXmFK8o8cmwgAeJFSBvt1bPdHCVKtaaV+WlAN36mpT4hcRpwbf3fY56ar2oIXzsBpOAiIRHAdY0OlQ==",
       "license": "MIT",
-      "dependencies": {
-        "loose-envify": "^1.1.0"
-      },
       "engines": {
         "node": ">=0.10.0"
       }
@@ -6367,16 +6363,15 @@
       }
     },
     "node_modules/react-dom": {
-      "version": "18.3.1",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
-      "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
+      "version": "19.2.7",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.7.tgz",
+      "integrity": "sha512-t0BRVXvbiE/o20Hfw669rLbMCDWtYZLvmJigy2f0MxsXF+71pxhR3xOkspmsO8h3ZlNzyibAmtCa3l4lYKk6gQ==",
       "license": "MIT",
       "dependencies": {
-        "loose-envify": "^1.1.0",
-        "scheduler": "^0.23.2"
+        "scheduler": "^0.27.0"
       },
       "peerDependencies": {
-        "react": "^18.3.1"
+        "react": "^19.2.7"
       }
     },
     "node_modules/react-is": {
@@ -6643,13 +6638,10 @@
       }
     },
     "node_modules/scheduler": {
-      "version": "0.23.2",
-      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.2.tgz",
-      "integrity": "sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==",
-      "license": "MIT",
-      "dependencies": {
-        "loose-envify": "^1.1.0"
-      }
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
+      "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
+      "license": "MIT"
     },
     "node_modules/semver": {
       "version": "7.7.3",

--- a/package.json
+++ b/package.json
@@ -21,20 +21,20 @@
   "license": "MPL-2",
   "keywords": [],
   "dependencies": {
-    "@helpwave/hightide": "^0.8.1",
+    "@helpwave/hightide": "^0.14.1",
     "@keycloakify/email-native": "~260007.0.0",
     "keycloakify": "^11.14.2",
     "lucide-react": "^0.563.0",
-    "react": "^18.2.0",
-    "react-dom": "^18.2.0"
+    "react": "^19.2.7",
+    "react-dom": "^19.2.7"
   },
   "devDependencies": {
     "@eslint/js": "^9.15.0",
     "@helpwave/eslint-config": "^0.0.11",
     "@storybook/react-vite": "^10.2.8",
     "@tailwindcss/vite": "^4.1.18",
-    "@types/react": "^18.2.43",
-    "@types/react-dom": "^18.2.17",
+    "@types/react": "^19.2.17",
+    "@types/react-dom": "^19.2.3",
     "@typescript-eslint/eslint-plugin": "^8.15.0",
     "@typescript-eslint/parser": "^8.15.0",
     "@vitejs/plugin-react": "^4.2.1",

--- a/src/login/components/RealmBanner.tsx
+++ b/src/login/components/RealmBanner.tsx
@@ -35,7 +35,8 @@ function KindIcon({ kind, className }: { kind: Exclude<RealmKind, 'customer'>, c
  * Full-width, sticky-top banner shown on every non-customer realm. Combines:
  * - bold colored bar across the viewport
  * - large realm name + icon
- * - 4 px outline around the page edge (driven by `--realm-accent`)
+ * - team realms: 4 px viewport outline (fixed, does not grow with scroll)
+ * - other non-customer realms: 4 px top stripe
  * - document title prefix so the realm is visible in the browser tab
  */
 export function RealmBanner({ kcContext }: RealmBannerProps) {
@@ -63,12 +64,22 @@ export function RealmBanner({ kcContext }: RealmBannerProps) {
     const headlineKey = HEADLINE[theme.kind]
     const subtitleKey = SUBTITLE[theme.kind]
 
+    const isTeamRealm = theme.kind === 'team'
+
     return (
         <>
             <style>{`
                 :root { --realm-accent: ${accent}; }
-                body { box-shadow: inset 0 4px 0 0 ${accent}; }
+                ${isTeamRealm ? '' : `body { box-shadow: inset 0 4px 0 0 ${accent}; }`}
             `}</style>
+
+            {isTeamRealm && (
+                <div
+                    aria-hidden="true"
+                    className="pointer-events-none fixed inset-0 z-[1200] box-border"
+                    style={{ boxShadow: `inset 0 0 0 4px ${accent}` }}
+                />
+            )}
 
             <div
                 role="banner"

--- a/src/login/pages/LoginOtp.tsx
+++ b/src/login/pages/LoginOtp.tsx
@@ -59,16 +59,13 @@ export default function LoginOtp({ kcContext }: LoginOtpProps) {
                                 <FormFieldLayout label={t('selectAuthenticatorTitle')} required>
                                     {({ id, ariaAttributes }) => (
                                         <Select
-                                            id={id}
                                             value={selectedCredentialId}
                                             onValueChange={(value: string) => setSelectedCredentialId(value)}
                                             onEditComplete={() => {}}
-                                            {...ariaAttributes}
+                                            buttonProps={{ id, ...ariaAttributes }}
                                         >
                                             {credentials.map((c) => (
-                                                <SelectOption key={c.id} value={c.id}>
-                                                    {c.userLabel}
-                                                </SelectOption>
+                                                <SelectOption key={c.id} value={c.id} label={c.userLabel} />
                                             ))}
                                         </Select>
                                     )}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- Upgrades `@helpwave/hightide` from `0.8.1` to `0.14.1` and bumps React to 19 to satisfy peer dependencies.
- Adapts `LoginOtp` to the updated Select API (`buttonProps` for field id/aria, required `label` on `SelectOption`).
- Restores the full blue (secondary) viewport outline for the **team** realm using a fixed overlay, so the border stays at 100% viewport height and no longer grows with page scroll.
- Admin and other non-customer realms keep the top-only accent stripe.

Footer imprint/privacy links already point to `https://helpwave.de/imprint` and `https://helpwave.de/privacy` — no change needed there.

## Test plan

- [x] `npm run typecheck`
- [x] `npm run lint`
- [x] `npm run build`
- [ ] Verify team realm login shows blue 4px border pinned to viewport edges
- [ ] Verify admin/other realms still show top stripe only
- [ ] Verify OTP page credential selector works with multiple sources
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f62f1a58-7252-402a-9cfd-e0b372ae7580"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f62f1a58-7252-402a-9cfd-e0b372ae7580"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

