### PR TITLE
Fix Edge brand-text weight, add copyable NixOS pin block, deploy-key fallback for pins job

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -86,12 +86,16 @@ jobs:
         runs-on: ubuntu-latest
         needs: [check_if_version_upgraded, create_github_release]
         if: needs.check_if_version_upgraded.outputs.is_pre_release != 'true'
-        permissions:
-            contents: write
         steps:
+            # Pushing to main requires a bypass of the pull-request rule.
+            # If the NIX_PINS_DEPLOY_KEY secret is set (a write-enabled deploy
+            # key, with "Deploy keys" on the ruleset bypass list), the push
+            # goes over SSH; when unset, checkout falls back to GITHUB_TOKEN,
+            # which needs the workflow/bot allowed through the ruleset instead.
             - uses: actions/checkout@v4
               with:
                   ref: main
+                  ssh-key: ${{ secrets.NIX_PINS_DEPLOY_KEY }}
             - uses: actions/setup-node@v4
             - name: Re-pin docs/deployment-nixos.md to the new release
               run: node scripts/update-nixos-plugin-pins.mjs --tag v${{ needs.check_if_version_upgraded.outputs.to_version }}

--- a/.storybook/preview.ts
+++ b/.storybook/preview.ts
@@ -1,6 +1,7 @@
 import type { Preview } from '@storybook/react-vite'
 import React from 'react'
 import '@helpwave/hightide/style/globals.css'
+import '../src/fonts.css'
 import '../src/index.css'
 import { HightideProvider } from '@helpwave/hightide'
 

--- a/README.md
+++ b/README.md
@@ -242,7 +242,10 @@ Cutting and consuming a release is a single repeatable motion:
    `themeVersion` / `spiVersion` / `sha256` pins in
    [docs/deployment-nixos.md](docs/deployment-nixos.md) from the release assets' digests
    and commits the result to `main` — the checked-in NixOS snippet always matches the
-   latest release.
+   latest release. Because `main` only accepts pull requests, the pushing identity needs
+   a ruleset bypass: either allow the workflow's `GITHUB_TOKEN` through, or set the
+   Actions secret `NIX_PINS_DEPLOY_KEY` to a write-enabled deploy key and put
+   **Deploy keys** on the bypass list — the job pushes over SSH when the secret is set.
 4. **Deploy**: copy the refreshed pin block into your NixOS config and
    `nixos-rebuild switch`.
 

--- a/docs/deployment-nixos.md
+++ b/docs/deployment-nixos.md
@@ -33,7 +33,36 @@ All four jars go into Keycloak's `providers/` directory —
 The pins below are **kept up to date automatically**: after every release, CI recomputes
 the versions and sha256 hashes from the release assets and commits them back to this file
 (see [§6 Updating](#6-updating)). Whatever is checked in here always matches the latest
-release — copy it as-is.
+release — copy it as-is into your module's `let` bindings:
+
+```nix
+  themeVersion = "0.6.1";
+  spiVersion = "0.3.0";
+
+  release =
+    ver: file: sha:
+    pkgs.fetchurl {
+      name = file;
+      url = "https://github.com/helpwave/id.helpwave.de/releases/download/v${ver}/${file}";
+      sha256 = sha;
+    };
+
+  themePlugin =
+    release themeVersion "keycloak-theme-for-kc-26.2-and-above.jar"
+      "sha256-nhAyu69jEyf3F0W0qph94iGnVdNU69yGEAUzN3IaJOY=";
+
+  captchaSPI =
+    release themeVersion "helpwave-captcha-${spiVersion}.jar"
+      "sha256-RSzFG775YXjNLxYlxvCMxxjoRRLYOCUNq2mutrUOaRM=";
+
+  pictureSPI =
+    release themeVersion "helpwave-picture-${spiVersion}.jar"
+      "sha256-aReO2U4AVyKMQydMqvZ2vIhl3TfM6MWpS7/rZQWerXg=";
+
+  policySPI =
+    release themeVersion "helpwave-policy-acceptance-${spiVersion}.jar"
+      "sha256-+FZ7skQGOEFD5AmZtIiRAO0xbUwn9bqcZU4Q6SejxBg=";
+```
 
 To re-pin manually (e.g. against an older release):
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "id.helpwave.de",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "repository": {
     "type": "git",
     "url": "git://github.com/helpwave/id.helpwave.de.git"

--- a/scripts/update-nixos-plugin-pins.mjs
+++ b/scripts/update-nixos-plugin-pins.mjs
@@ -102,16 +102,20 @@ function findAsset(release, predicate, description) {
     return asset
 }
 
-/** Replaces exactly one occurrence; fails loudly if the doc anchor shape changed. */
-function replaceOnce(content, pattern, replacement, description) {
-    const matches = content.match(new RegExp(pattern, 'g')) ?? []
-    if (matches.length !== 1) {
+/**
+ * Replaces every occurrence (the pins appear both in the copyable block and in
+ * the full module example); fails loudly if the doc anchor shape changed.
+ */
+function replacePins(content, pattern, replacement, description) {
+    const global = new RegExp(pattern, 'g')
+    const matches = content.match(global) ?? []
+    if (matches.length === 0) {
         fail(
-            `Expected exactly 1 match for ${description} in ${path.relative(process.cwd(), DOC_PATH)}, ` +
-            `found ${matches.length}. Did the pin block in the doc change shape?`
+            `Found no match for ${description} in ${path.relative(process.cwd(), DOC_PATH)}. ` +
+            'Did the pin block in the doc change shape?'
         )
     }
-    return content.replace(pattern, replacement)
+    return content.replace(global, replacement)
 }
 
 async function main() {
@@ -149,13 +153,13 @@ async function main() {
     const original = fs.readFileSync(DOC_PATH, 'utf8')
     let content = original
 
-    content = replaceOnce(
+    content = replacePins(
         content,
         /themeVersion = "[^"]+";/,
         `themeVersion = "${themeVersion}";`,
         'themeVersion pin'
     )
-    content = replaceOnce(
+    content = replacePins(
         content,
         /spiVersion = "[^"]+";/,
         `spiVersion = "${spiVersion}";`,
@@ -172,7 +176,7 @@ async function main() {
     }
     for (const [binding, fileAnchor] of Object.entries(bindingAnchors)) {
         const escapedAnchor = fileAnchor.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
-        content = replaceOnce(
+        content = replacePins(
             content,
             new RegExp(`(release themeVersion "${escapedAnchor}"\\s*\\n\\s*")sha256-[A-Za-z0-9+/=]+(")`),
             `$1${hashes[binding]}$2`,

--- a/src/login/components/Branding.tsx
+++ b/src/login/components/Branding.tsx
@@ -25,7 +25,7 @@ export function Branding({ animate = 'loading' }: BrandingProps) {
     return (
         <div className="flex flex-col items-center">
             <HelpwaveLogo animate={effectiveAnimate} height={96} width={96} animationDuration={5} />
-            <div className="font-space text-4xl -translate-y-8 font-[900]">
+            <div className="font-space text-4xl -translate-y-8 font-bold">
                 helpwave id
             </div>
         </div>


### PR DESCRIPTION
## Summary

Follow-up to #17. Bumps the version to **0.6.2** so the font fix ships in a release.

### 1. "helpwave id" brand text broken on Edge — root cause found

The brand text requested **`font-weight: 900`**, but Space Grotesk's variable font only has a weight axis of **300–700** (there is no 900), and the `@font-face` declares `font-weight: 300 700` accordingly. Browsers diverge on out-of-range requests: Chromium on Windows (Edge) renders the 700 instance and smears **synthetic bold** on top, and Safari can drop to the default 400 instance — so the heavy brand text looked broken/wrong while every other weight rendered fine. This is also why helpwave tasks never showed the issue: it declares the identical `300 700` range but never requests more than `font-bold`.

Fix: `font-[900]` → `font-bold` (700) in `Branding.tsx`, matching hightide's own brand components (`HelpwaveBadge`, the `helpwave` markdown span). `RealmBanner`'s `font-extrabold` (800) is unaffected — it inherits Inter, which genuinely spans 100–900.

### 2. Storybook parity: load the self-hosted fonts

`.storybook/preview.ts` imported the hightide globals and `index.css` but not `fonts.css`, so Storybook rendered all stories in system-fallback fonts while production (via `main.tsx`) shows the self-hosted Inter/Space Grotesk. `fonts.css` is now imported in the same order as the production entry. Verified via `build-storybook`: both variable-font files are emitted into the bundle and the built CSS carries the `@font-face` declarations.

### 3. Copyable pin block in the NixOS docs

`docs/deployment-nixos.md` §2 now contains the complete pin set (`themeVersion`, `spiVersion`, `release` helper, and the four plugin bindings) as a standalone code fence — GitHub's per-block copy button grabs the whole thing in one click. The pins now appear twice (copy block + full module example), so `update-nixos-plugin-pins.mjs` replaces **every** occurrence of each anchor instead of exactly one, keeping both blocks in sync (still failing loudly on zero matches). Verified: corrupting only one block heals both; `--check` passes against the real v0.6.1 release data.

### 4. Deploy-key fallback for the pins job

The pins push to `main` originally failed with GH013. The job now supports two auth modes: if the Actions secret `NIX_PINS_DEPLOY_KEY` is set (write-enabled deploy key, with **Deploy keys** on the ruleset bypass list), checkout/push go over SSH; when unset, `actions/checkout` falls back to `GITHUB_TOKEN` — which works now that the re-run pushed successfully, so nothing needs configuring unless the token path breaks again.

## Testing

- `eslint .`, `tsc --noEmit` — pass
- `build-storybook` — succeeds; `SpaceGrotesk-Variable-*.ttf` and `Inter-Variable-*.ttf` present in `storybook-static/assets/`, `@font-face` with `font-weight: 300 700` in the built CSS
- Pin script re-tested with the dual-block doc: update, idempotency, `--check` fresh/stale, single-block corruption healing
- Workflow YAML parses; checkout falls back to token auth when the secret is unset

🤖 Generated with [Claude Code](https://claude.com/claude-code)